### PR TITLE
feat(json): add DiscardUnknown for invalid enum strings

### DIFF
--- a/json/unmarshal.go
+++ b/json/unmarshal.go
@@ -40,6 +40,11 @@ func (e *unmarshalError) Unwrap() error {
 type UnmarshalerConfig struct {
 	// AnyTypeResolver is the resolver function for the any well-known type.
 	AnyTypeResolver anypb_resolver.AnyTypeResolver
+	// DiscardUnknown, if true, ignores unknown enum string values and leaves the
+	// field at its zero value instead of failing unmarshaling. This matches
+	// google.golang.org/protobuf encoding/protojson UnmarshalOptions.DiscardUnknown
+	// behavior for invalid enum names.
+	DiscardUnknown bool
 }
 
 // DefaultUnmarshalerConfig is the default configuration for the Unmarshaler.
@@ -799,6 +804,9 @@ func (s *UnmarshalState) ReadEnum(valueMaps ...map[string]int32) int32 {
 		v := s.inner.ReadString()
 		x, err := ParseEnumString(v, valueMaps...)
 		if err != nil {
+			if s.config != nil && s.config.DiscardUnknown {
+				return 0
+			}
 			s.SetErrorf("unknown value for enum: %q", v)
 			return 0
 		}

--- a/json/unmarshal_test.go
+++ b/json/unmarshal_test.go
@@ -248,3 +248,66 @@ func TestUnmarshaler(t *testing.T) {
 		return s.ReadFieldMask().GetPaths()
 	}, `{"paths":["foo","bar","baz.qux"]}`, []string{"foo", "bar", "baz.qux"})
 }
+
+func TestReadEnumDiscardUnknown(t *testing.T) {
+	valueMap := map[string]int32{
+		"APP_FLAVOR_UNSPECIFIED": 0,
+		"BETA":                   1,
+		"NORMAL":                 5,
+	}
+
+	t.Run("known string", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"NORMAL"`), UnmarshalerConfig{})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 5 {
+			t.Fatalf("got %d, want 5", got)
+		}
+	})
+
+	t.Run("unknown string errors by default", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"normal"`), UnmarshalerConfig{})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err == nil {
+			t.Fatal("expected error for unknown enum string")
+		}
+		if got != 0 {
+			t.Fatalf("got %d, want 0", got)
+		}
+	})
+
+	t.Run("unknown string discarded when DiscardUnknown", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"normal"`), UnmarshalerConfig{DiscardUnknown: true})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("got %d, want 0", got)
+		}
+	})
+
+	t.Run("unknown name discarded when DiscardUnknown", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"nope"`), UnmarshalerConfig{DiscardUnknown: true})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("got %d, want 0", got)
+		}
+	})
+
+	t.Run("numeric still works with DiscardUnknown", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`5`), UnmarshalerConfig{DiscardUnknown: true})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 5 {
+			t.Fatalf("got %d, want 5", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `UnmarshalerConfig.DiscardUnknown` (default `false`)
- When enabled, `ReadEnum` ignores unknown enum **string** values and returns `0` instead of erroring — same as `protojson.UnmarshalOptions{DiscardUnknown: true}` for invalid enum names
- Known names and numeric values are unchanged
- Unit tests cover known / unknown / discard / numeric cases

## Motivation
`protojson` supports `UnmarshalOptions{DiscardUnknown: true}`, which silently leaves unknown enum string values at the proto3 zero value instead of failing unmarshal. This library previously always errored on unknown enum strings (e.g. `"normal"` when the enum only defines `"NORMAL"`), which breaks drop-in parity for callers migrating from `protojson`.

Example (illustrative only): JSON `"app_flavor": "normal"` with a defined enum value `NORMAL = 5` fails here today with `unknown value for enum: "normal"`, while `protojson` with `DiscardUnknown: true` accepts the message and leaves the field as `UNSPECIFIED (0)`.

## Usage with generated `UnmarshalJSON`
Generated code uses `json.DefaultUnmarshalerConfig`. Enable discard globally:

```go
func init() {
	json.DefaultUnmarshalerConfig.DiscardUnknown = true
}
```

Or pass a custom config into `UnmarshalerConfig{DiscardUnknown: true}.Unmarshal(...)`.

## Test plan
- [x] `go test ./... -count=1`
- [x] Confirm known enum names and numeric values still map correctly
- [x] Confirm unknown enum strings still error when `DiscardUnknown` is false
- [x] Confirm unknown enum strings become `0` when `DiscardUnknown` is true


Made with [Cursor](https://cursor.com)