### PR TITLE
fix(json): treat JSON null as unspecified for enums

### DIFF
--- a/json/unmarshal.go
+++ b/json/unmarshal.go
@@ -811,6 +811,9 @@ func (s *UnmarshalState) ReadEnum(valueMaps ...map[string]int32) int32 {
 			return 0
 		}
 		return x
+	case jsoniter.NilValue:
+		s.inner.ReadNil()
+		return 0
 	default:
 		s.SetErrorf("invalid value type for enum: %s", valueTypeString(nextTok))
 		return 0

--- a/json/unmarshal_test.go
+++ b/json/unmarshal_test.go
@@ -310,4 +310,15 @@ func TestReadEnumDiscardUnknown(t *testing.T) {
 			t.Fatalf("got %d, want 5", got)
 		}
 	})
+
+	t.Run("null returns zero without error", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`null`), UnmarshalerConfig{})
+		got := s.ReadEnum(valueMap)
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("got %d, want 0", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- `ReadEnum` accepts JSON `null` and returns `0` (same as a missing field)
- Matches `google.golang.org/protobuf/encoding/protojson` for ordinary enums (null is skipped unless the field is `google.protobuf.Value` / `NullValue`)
- Independent of `DiscardUnknown` (that only covers unknown enum *string* names)

Fixes real-world convert failures where clients send `"some_enum": null` (e.g. Blinkit `supply_training_events.training_source_app_type`).

## Test plan
- [x] `go test ./json/ -run TestReadEnum` (includes `null returns zero without error`)


Made with [Cursor](https://cursor.com)