### PR TITLE
fix(json): match protojson numeric parsing for ints/floats

### DIFF
--- a/json/number_parse.go
+++ b/json/number_parse.go
@@ -1,0 +1,150 @@
+package json
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+func isJSONNumberNonDelim(c byte) bool {
+	return c == '-' || c == '+' || c == '.' || c == '_' ||
+		('a' <= c && c <= 'z') ||
+		('A' <= c && c <= 'Z') ||
+		('0' <= c && c <= '9')
+}
+
+func scanJSONNumber(input string) (int, bool) {
+	s := input
+	n := 0
+	if len(s) == 0 {
+		return 0, false
+	}
+	if s[0] == '-' {
+		s = s[1:]
+		n++
+		if len(s) == 0 {
+			return 0, false
+		}
+	}
+	switch {
+	case s[0] == '0':
+		s = s[1:]
+		n++
+	case '1' <= s[0] && s[0] <= '9':
+		s = s[1:]
+		n++
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+			n++
+		}
+	default:
+		return 0, false
+	}
+	if len(s) >= 2 && s[0] == '.' && '0' <= s[1] && s[1] <= '9' {
+		s = s[2:]
+		n += 2
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+			n++
+		}
+	}
+	if len(s) >= 2 && (s[0] == 'e' || s[0] == 'E') {
+		s = s[1:]
+		n++
+		if s[0] == '+' || s[0] == '-' {
+			s = s[1:]
+			n++
+			if len(s) == 0 {
+				return 0, false
+			}
+		}
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+			n++
+		}
+	}
+	if n < len(input) && isJSONNumberNonDelim(input[n]) {
+		return 0, false
+	}
+	return n, true
+}
+
+func parseSignedIntLenient(s string, bitSize int) (int64, error) {
+	if len(s) != len(strings.TrimSpace(s)) {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	n, ok := scanJSONNumber(s)
+	if !ok {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	return intFromJSONNumber(s[:n], bitSize)
+}
+
+func parseUnsignedIntLenient(s string, bitSize int) (uint64, error) {
+	if len(s) != len(strings.TrimSpace(s)) {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	n, ok := scanJSONNumber(s)
+	if !ok {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	return uintFromJSONNumber(s[:n], bitSize)
+}
+
+func parseFloatLenient(s string, bitSize int) (float64, error) {
+	switch s {
+	case "NaN":
+		return math.NaN(), nil
+	case "Infinity":
+		return math.Inf(1), nil
+	case "-Infinity":
+		return math.Inf(-1), nil
+	}
+	if len(s) != len(strings.TrimSpace(s)) {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	n, ok := scanJSONNumber(s)
+	if !ok {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	return strconv.ParseFloat(s[:n], bitSize)
+}
+
+func intFromJSONNumber(num string, bitSize int) (int64, error) {
+	if v, err := strconv.ParseInt(num, 10, bitSize); err == nil {
+		return v, nil
+	}
+	f, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	v := int64(f)
+	if bitSize == 32 {
+		if v < math.MinInt32 || v > math.MaxInt32 {
+			return 0, fmt.Errorf("value out of range")
+		}
+	}
+	return v, nil
+}
+
+func uintFromJSONNumber(num string, bitSize int) (uint64, error) {
+	if v, err := strconv.ParseUint(num, 10, bitSize); err == nil {
+		return v, nil
+	}
+	f, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) || f < 0 || math.Trunc(f) != f {
+		return 0, fmt.Errorf("invalid syntax")
+	}
+	v := uint64(f)
+	if bitSize == 32 && v > math.MaxUint32 {
+		return 0, fmt.Errorf("value out of range")
+	}
+	return v, nil
+}

--- a/json/number_parse.go
+++ b/json/number_parse.go
@@ -70,7 +70,7 @@ func scanJSONNumber(input string) (int, bool) {
 	return n, true
 }
 
-func parseSignedIntLenient(s string, bitSize int) (int64, error) {
+func parseJSONInt(s string, bitSize int) (int64, error) {
 	if len(s) != len(strings.TrimSpace(s)) {
 		return 0, fmt.Errorf("invalid syntax")
 	}
@@ -81,7 +81,7 @@ func parseSignedIntLenient(s string, bitSize int) (int64, error) {
 	return intFromJSONNumber(s[:n], bitSize)
 }
 
-func parseUnsignedIntLenient(s string, bitSize int) (uint64, error) {
+func parseJSONUint(s string, bitSize int) (uint64, error) {
 	if len(s) != len(strings.TrimSpace(s)) {
 		return 0, fmt.Errorf("invalid syntax")
 	}
@@ -92,7 +92,7 @@ func parseUnsignedIntLenient(s string, bitSize int) (uint64, error) {
 	return uintFromJSONNumber(s[:n], bitSize)
 }
 
-func parseFloatLenient(s string, bitSize int) (float64, error) {
+func parseJSONFloat(s string, bitSize int) (float64, error) {
 	switch s {
 	case "NaN":
 		return math.NaN(), nil

--- a/json/unmarshal.go
+++ b/json/unmarshal.go
@@ -171,7 +171,7 @@ func (s *UnmarshalState) ReadFloat32() float32 {
 	case jsoniter.NumberValue:
 		return s.inner.ReadFloat32()
 	case jsoniter.StringValue:
-		f, err := strconv.ParseFloat(s.inner.ReadString(), 32)
+		f, err := parseFloatLenient(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for float32: %w", err)
 			return 0
@@ -213,7 +213,7 @@ func (s *UnmarshalState) ReadFloat64() float64 {
 	case jsoniter.NumberValue:
 		return s.inner.ReadFloat64()
 	case jsoniter.StringValue:
-		f, err := strconv.ParseFloat(s.inner.ReadString(), 64)
+		f, err := parseFloatLenient(s.inner.ReadString(), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for float64: %w", err)
 			return 0
@@ -285,14 +285,19 @@ func (s *UnmarshalState) ReadInt32() int32 {
 	nextTok := s.inner.WhatIsNext()
 	switch nextTok {
 	case jsoniter.NumberValue:
-		return s.inner.ReadInt32()
-	case jsoniter.StringValue:
-		f, err := strconv.ParseInt(s.inner.ReadString(), 10, 32)
+		v, err := intFromJSONNumber(string(s.inner.ReadNumber()), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for int32: %w", err)
 			return 0
 		}
-		return int32(f)
+		return int32(v)
+	case jsoniter.StringValue:
+		v, err := parseSignedIntLenient(s.inner.ReadString(), 32)
+		if err != nil {
+			s.SetErrorf("invalid value for int32: %w", err)
+			return 0
+		}
+		return int32(v)
 	default:
 		s.SetErrorf("invalid value type for int32: %s", valueTypeString(nextTok))
 		return 0
@@ -327,14 +332,19 @@ func (s *UnmarshalState) ReadInt64() int64 {
 	nextTok := s.inner.WhatIsNext()
 	switch nextTok {
 	case jsoniter.NumberValue:
-		return s.inner.ReadInt64()
-	case jsoniter.StringValue:
-		f, err := strconv.ParseInt(s.inner.ReadString(), 10, 64)
+		v, err := intFromJSONNumber(string(s.inner.ReadNumber()), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for int64: %w", err)
 			return 0
 		}
-		return f
+		return v
+	case jsoniter.StringValue:
+		v, err := parseSignedIntLenient(s.inner.ReadString(), 64)
+		if err != nil {
+			s.SetErrorf("invalid value for int64: %w", err)
+			return 0
+		}
+		return v
 	default:
 		s.SetErrorf("invalid value type for int64: %s", valueTypeString(nextTok))
 		return 0
@@ -401,14 +411,19 @@ func (s *UnmarshalState) ReadUint32() uint32 {
 	nextTok := s.inner.WhatIsNext()
 	switch nextTok {
 	case jsoniter.NumberValue:
-		return s.inner.ReadUint32()
-	case jsoniter.StringValue:
-		f, err := strconv.ParseUint(s.inner.ReadString(), 10, 32)
+		v, err := uintFromJSONNumber(string(s.inner.ReadNumber()), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for uint32: %w", err)
 			return 0
 		}
-		return uint32(f)
+		return uint32(v)
+	case jsoniter.StringValue:
+		v, err := parseUnsignedIntLenient(s.inner.ReadString(), 32)
+		if err != nil {
+			s.SetErrorf("invalid value for uint32: %w", err)
+			return 0
+		}
+		return uint32(v)
 	default:
 		s.SetErrorf("invalid value type for uint32: %s", valueTypeString(nextTok))
 		return 0
@@ -443,14 +458,19 @@ func (s *UnmarshalState) ReadUint64() uint64 {
 	nextTok := s.inner.WhatIsNext()
 	switch nextTok {
 	case jsoniter.NumberValue:
-		return s.inner.ReadUint64()
-	case jsoniter.StringValue:
-		f, err := strconv.ParseUint(s.inner.ReadString(), 10, 64)
+		v, err := uintFromJSONNumber(string(s.inner.ReadNumber()), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for uint64: %w", err)
 			return 0
 		}
-		return f
+		return v
+	case jsoniter.StringValue:
+		v, err := parseUnsignedIntLenient(s.inner.ReadString(), 64)
+		if err != nil {
+			s.SetErrorf("invalid value for uint64: %w", err)
+			return 0
+		}
+		return v
 	default:
 		s.SetErrorf("invalid value type for uint64: %s", valueTypeString(nextTok))
 		return 0

--- a/json/unmarshal.go
+++ b/json/unmarshal.go
@@ -171,7 +171,7 @@ func (s *UnmarshalState) ReadFloat32() float32 {
 	case jsoniter.NumberValue:
 		return s.inner.ReadFloat32()
 	case jsoniter.StringValue:
-		f, err := parseFloatLenient(s.inner.ReadString(), 32)
+		f, err := parseJSONFloat(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for float32: %w", err)
 			return 0
@@ -213,7 +213,7 @@ func (s *UnmarshalState) ReadFloat64() float64 {
 	case jsoniter.NumberValue:
 		return s.inner.ReadFloat64()
 	case jsoniter.StringValue:
-		f, err := parseFloatLenient(s.inner.ReadString(), 64)
+		f, err := parseJSONFloat(s.inner.ReadString(), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for float64: %w", err)
 			return 0
@@ -292,7 +292,7 @@ func (s *UnmarshalState) ReadInt32() int32 {
 		}
 		return int32(v)
 	case jsoniter.StringValue:
-		v, err := parseSignedIntLenient(s.inner.ReadString(), 32)
+		v, err := parseJSONInt(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for int32: %w", err)
 			return 0
@@ -339,7 +339,7 @@ func (s *UnmarshalState) ReadInt64() int64 {
 		}
 		return v
 	case jsoniter.StringValue:
-		v, err := parseSignedIntLenient(s.inner.ReadString(), 64)
+		v, err := parseJSONInt(s.inner.ReadString(), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for int64: %w", err)
 			return 0
@@ -418,7 +418,7 @@ func (s *UnmarshalState) ReadUint32() uint32 {
 		}
 		return uint32(v)
 	case jsoniter.StringValue:
-		v, err := parseUnsignedIntLenient(s.inner.ReadString(), 32)
+		v, err := parseJSONUint(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for uint32: %w", err)
 			return 0
@@ -465,7 +465,7 @@ func (s *UnmarshalState) ReadUint64() uint64 {
 		}
 		return v
 	case jsoniter.StringValue:
-		v, err := parseUnsignedIntLenient(s.inner.ReadString(), 64)
+		v, err := parseJSONUint(s.inner.ReadString(), 64)
 		if err != nil {
 			s.SetErrorf("invalid value for uint64: %w", err)
 			return 0

--- a/json/unmarshal.go
+++ b/json/unmarshal.go
@@ -290,14 +290,14 @@ func (s *UnmarshalState) ReadInt32() int32 {
 			s.SetErrorf("invalid value for int32: %w", err)
 			return 0
 		}
-		return int32(v)
+		return int32(v) //nolint:gosec // bounded by intFromJSONNumber bitSize 32
 	case jsoniter.StringValue:
 		v, err := parseJSONInt(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for int32: %w", err)
 			return 0
 		}
-		return int32(v)
+		return int32(v) //nolint:gosec // bounded by parseJSONInt bitSize 32
 	default:
 		s.SetErrorf("invalid value type for int32: %s", valueTypeString(nextTok))
 		return 0
@@ -416,14 +416,14 @@ func (s *UnmarshalState) ReadUint32() uint32 {
 			s.SetErrorf("invalid value for uint32: %w", err)
 			return 0
 		}
-		return uint32(v)
+		return uint32(v) //nolint:gosec // bounded by uintFromJSONNumber bitSize 32
 	case jsoniter.StringValue:
 		v, err := parseJSONUint(s.inner.ReadString(), 32)
 		if err != nil {
 			s.SetErrorf("invalid value for uint32: %w", err)
 			return 0
 		}
-		return uint32(v)
+		return uint32(v) //nolint:gosec // bounded by parseJSONUint bitSize 32
 	default:
 		s.SetErrorf("invalid value type for uint32: %s", valueTypeString(nextTok))
 		return 0

--- a/json/unmarshal_test.go
+++ b/json/unmarshal_test.go
@@ -312,7 +312,7 @@ func TestReadEnumDiscardUnknown(t *testing.T) {
 	})
 }
 
-func TestProtoJSONNumericLeniency(t *testing.T) {
+func TestProtoJSONNumericParsing(t *testing.T) {
 	t.Run("int64 string float looking", func(t *testing.T) {
 		s := NewUnmarshalState([]byte(`"215.0"`), UnmarshalerConfig{})
 		got := s.ReadInt64()

--- a/json/unmarshal_test.go
+++ b/json/unmarshal_test.go
@@ -311,3 +311,76 @@ func TestReadEnumDiscardUnknown(t *testing.T) {
 		}
 	})
 }
+
+func TestProtoJSONNumericLeniency(t *testing.T) {
+	t.Run("int64 string float looking", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"215.0"`), UnmarshalerConfig{})
+		got := s.ReadInt64()
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 215 {
+			t.Fatalf("got %d, want 215", got)
+		}
+	})
+
+	t.Run("int32 number float looking", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`215.0`), UnmarshalerConfig{})
+		got := s.ReadInt32()
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 215 {
+			t.Fatalf("got %d, want 215", got)
+		}
+	})
+
+	t.Run("int64 trailing junk after number", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"50$ OFF"`), UnmarshalerConfig{})
+		got := s.ReadInt64()
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 50 {
+			t.Fatalf("got %d, want 50", got)
+		}
+	})
+
+	t.Run("float64 trailing junk after number", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"10 mins"`), UnmarshalerConfig{})
+		got := s.ReadFloat64()
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 10 {
+			t.Fatalf("got %v, want 10", got)
+		}
+	})
+
+	t.Run("int64 rejects non integral fraction", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"215.5"`), UnmarshalerConfig{})
+		_ = s.ReadInt64()
+		if err := s.Err(); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("int64 rejects letter suffix", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"50abc"`), UnmarshalerConfig{})
+		_ = s.ReadInt64()
+		if err := s.Err(); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("int64 scientific", func(t *testing.T) {
+		s := NewUnmarshalState([]byte(`"1.23e3"`), UnmarshalerConfig{})
+		got := s.ReadInt64()
+		if err := s.Err(); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got != 1230 {
+			t.Fatalf("got %d, want 1230", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Align lite int/uint/float JSON unmarshaling with Go `protojson`: accept integral floats (`215.0`, `"1.23e3"`) and leading JSON numbers with trailing delimiter junk (`"50$ OFF"` → 50, `"10 mins"` → 10).
- Still rejects non-integral fractions (`215.5`) and letter-glued suffixes (`50abc`).

## Spec vs Go protojson
- **`215.0` → int — ProtoJSON standard.** Spec allows a zero fractional part for integer fields (`1.0` OK, `1.5` not). See [ProtoJSON / out-of-range numeric values](https://protobuf.dev/programming-guides/json/).
- **`"50$ OFF"` / `"10 mins"` — not in the ProtoJSON spec.** Go `protojson` quirk: it parses a leading JSON number from the string and ignores the rest. Other language runtimes are not required to do this. We match it for parity with `google.golang.org/protobuf/encoding/protojson`.

## Test plan
- [x] `go test ./json/`

Made with [Cursor](https://cursor.com)