### PR TITLE
feat(registry): opt-in message registry with flattened custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Summary of the packages provided by this module:
 *   [`cmd/protoc-gen-go-lite`](https://pkg.go.dev/github.com/aperturerobotics/protobuf-go-lite/cmd/protoc-gen-go-lite):
     The `protoc-gen-go-lite` binary is a protoc plugin to generate a Go protocol
     buffer package.
+*   [`registry`](https://pkg.go.dev/github.com/aperturerobotics/protobuf-go-lite/registry):
+    Package `registry` indexes generated message constructors and custom
+    message options without runtime reflection.
 
 ## Usage
 
@@ -125,6 +128,37 @@ Check out the [template](https://github.com/aperturerobotics/template) for a qui
 Both modes are selected at generation time and produce normal Go packages for
 callers. They do not add a reflection registry, descriptor builder, struct tag
 interpreter, or runtime type-metadata dependency to generated fast paths.
+
+### Opt-in message registry
+
+Generated packages do not register message types by default. Add `registry=true`
+to `--go-lite_opt` when an application must discover linked message types at
+runtime:
+
+```
+protoc --go-lite_out=. --go-lite_opt=features=all,registry=true example.proto
+```
+
+The registry requires the `size`, `marshal`, and `unmarshal` features. Each
+generated package registers constructors by fully qualified protobuf name and
+`google.protobuf.Any` type URL during package initialization. The generator
+also flattens custom message options into fully qualified scalar paths:
+
+```go
+registry.Range(func(entry registry.Entry) bool {
+	tenant, tenantOK := entry.Option("annotations.msg_opts.tenant")
+	table, tableOK := entry.Option("annotations.msg_opts.table")
+	if tenantOK && tableOK {
+		messagesByKey[tenant+"."+table] = entry
+	}
+	return true
+})
+```
+
+Repeated option values retain declaration order. Message-valued options use
+dot-separated field paths, and enum values use their protobuf names. The
+registry copies option metadata on registration and returns sorted snapshots to
+callers.
 
 ### Generated output
 

--- a/cmd/protoc-gen-go-lite/main.go
+++ b/cmd/protoc-gen-go-lite/main.go
@@ -44,6 +44,7 @@ func main() {
 	f.StringVar(&codegenMode, "codegen", string(generator.CodegenModeHelper), "code generation mode: helper or unrolled")
 	f.StringVar(&features, "features", "all", "list of features to generate (separated by '+')")
 	f.StringVar(&cfg.BuildTag, "buildTag", "", "the go:build tag to set on generated files")
+	f.BoolVar(&cfg.Registry, "registry", false, "generate init-time message registry with flattened custom options")
 
 	protogen.Options{
 		ParamFunc: f.Set,
@@ -51,7 +52,8 @@ func main() {
 		if err := cfg.SetCodegenMode(codegenMode); err != nil {
 			return err
 		}
-		gen, err := generator.NewGenerator(plugin, strings.Split(features, "+"), &cfg)
+		featureNames := strings.Split(features, "+")
+		gen, err := generator.NewGenerator(plugin, featureNames, &cfg)
 		if err != nil {
 			return err
 		}

--- a/cmd/protoc-gen-go-lite/registry_test.go
+++ b/cmd/protoc-gen-go-lite/registry_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const registryAnnotationsProto = `syntax = "proto3";
+
+package annotations;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "registryfixture;registryfixture";
+
+extend google.protobuf.MessageOptions {
+  MsgOpts msg_opts = 50000;
+}
+
+enum Region {
+  REGION_UNSPECIFIED = 0;
+  REGION_US_EAST_2 = 1;
+}
+
+message Lifecycle {
+  Region region = 1;
+  repeated string tags = 2;
+}
+
+message MsgOpts {
+  string tenant = 1;
+  string table = 2;
+  repeated string tenants = 3;
+  Lifecycle lifecycle = 4;
+  float weight = 5;
+}
+`
+
+const registryEventsProto = `syntax = "proto3";
+
+package demo;
+
+import "annotations.proto";
+
+option go_package = "registryfixture;registryfixture";
+
+message ClickEvents {
+  option (annotations.msg_opts) = {
+    tenant: "BLINKIT"
+    table: "click_events"
+    tenants: "BLINKIT"
+    tenants: "ZOMATO"
+    lifecycle: {
+      region: REGION_US_EAST_2
+      tags: "a"
+      tags: "b"
+    }
+    weight: 0.1
+  };
+
+  string id = 1;
+}
+
+message NestedHolder {
+  message Inner {
+    option (annotations.msg_opts).tenant = "ZOMATO";
+    option (annotations.msg_opts).table = "inner";
+    int32 value = 1;
+  }
+  Inner inner = 1;
+}
+`
+
+func TestRegistryOptInGeneratesInitAndOptions(t *testing.T) {
+	root := repoRoot(t)
+	plugin := buildCurrentPlugin(t, root)
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "annotations.proto"), registryAnnotationsProto)
+	writeFile(t, filepath.Join(dir, "events.proto"), registryEventsProto)
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(
+		"protoc",
+		"-I", dir,
+		"-I", protobufSourceDir(t, root),
+		"--plugin=protoc-gen-go-lite="+plugin,
+		"--go-lite_out="+outDir,
+		"--go-lite_opt=features=size+marshal+unmarshal,paths=source_relative,registry=true",
+		"annotations.proto",
+		"events.proto",
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generate registry fixture:\n%s", out)
+	}
+
+	eventsOut := string(readFile(t, filepath.Join(outDir, "events.pb.go")))
+	assertContainsAll(t, eventsOut, "registry output", []string{
+		`registry.Register(registry.Entry{`,
+		`FullName: "demo.ClickEvents"`,
+		`type.googleapis.com/demo.ClickEvents`,
+		`annotations.msg_opts.tenant`,
+		`"BLINKIT"`,
+		`annotations.msg_opts.table`,
+		`"click_events"`,
+		`annotations.msg_opts.tenants`,
+		`"ZOMATO"`,
+		`annotations.msg_opts.lifecycle.region`,
+		`"REGION_US_EAST_2"`,
+		`annotations.msg_opts.lifecycle.tags`,
+		`"a"`,
+		`"b"`,
+		`annotations.msg_opts.weight`,
+		`FullName: "demo.NestedHolder"`,
+		`FullName: "demo.NestedHolder.Inner"`,
+		`return new(ClickEvents)`,
+	})
+
+	writeFile(t, filepath.Join(outDir, "go.mod"), "module registryfixture\n\ngo 1.23\n\nrequire github.com/aperturerobotics/protobuf-go-lite v0.0.0\n\nreplace github.com/aperturerobotics/protobuf-go-lite => "+root+"\n")
+	writeFile(t, filepath.Join(outDir, "registry_runtime_test.go"), `package registryfixture
+
+import (
+	"testing"
+
+	"github.com/aperturerobotics/protobuf-go-lite/registry"
+)
+
+func TestRuntimeRegistry(t *testing.T) {
+	msg, ok := registry.NewByName("demo.ClickEvents")
+	if !ok {
+		t.Fatal("missing ClickEvents")
+	}
+	if _, ok := msg.(*ClickEvents); !ok {
+		t.Fatalf("got %T", msg)
+	}
+
+	var weight string
+	byKey := map[string]registry.Entry{}
+	registry.Range(func(e registry.Entry) bool {
+		tenant, tenantOK := e.Option("annotations.msg_opts.tenant")
+		table, tableOK := e.Option("annotations.msg_opts.table")
+		if tenantOK && tableOK {
+			byKey[tenant+"."+table] = e
+		}
+		if e.FullName == "demo.ClickEvents" {
+			weight, _ = e.Option("annotations.msg_opts.weight")
+		}
+		return true
+	})
+	if weight != "0.1" {
+		t.Fatalf("weight=%q, want 0.1", weight)
+	}
+	if _, ok := byKey["BLINKIT.click_events"]; !ok {
+		t.Fatalf("missing tenant.table key: %#v", byKey)
+	}
+	if _, ok := byKey["ZOMATO.inner"]; !ok {
+		t.Fatalf("missing nested key: %#v", byKey)
+	}
+}
+`)
+
+	testCmd := exec.Command("go", "test", "-mod=mod", "./...")
+	testCmd.Dir = outDir
+	testOut, err := testCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated registry package should compile and pass:\n%s", testOut)
+	}
+}
+
+func TestRegistryDisabledByDefault(t *testing.T) {
+	root := repoRoot(t)
+	plugin := buildCurrentPlugin(t, root)
+	protoPath := writeTempProto(t, `syntax = "proto3";
+package noreg;
+option go_package = "noreg;noreg";
+message Msg { int32 v = 1; }
+`)
+	outDir := t.TempDir()
+	cmd := exec.Command(
+		"protoc",
+		"-I", filepath.Dir(protoPath),
+		"--plugin=protoc-gen-go-lite="+plugin,
+		"--go-lite_out="+outDir,
+		"--go-lite_opt=features=size+marshal+unmarshal,paths=source_relative",
+		protoPath,
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generate:\n%s", out)
+	}
+	content := string(readFile(t, filepath.Join(outDir, filepath.Base(strings.TrimSuffix(protoPath, ".proto")+".pb.go"))))
+	if strings.Contains(content, "registry.Register") {
+		t.Fatal("registry should be opt-in")
+	}
+}
+
+func TestRegistryRequiresFeatures(t *testing.T) {
+	root := repoRoot(t)
+	plugin := buildCurrentPlugin(t, root)
+	protoPath := writeTempProto(t, `syntax = "proto3";
+package badreg;
+option go_package = "badreg;badreg";
+message Msg { int32 v = 1; }
+`)
+	outDir := t.TempDir()
+	cmd := exec.Command(
+		"protoc",
+		"-I", filepath.Dir(protoPath),
+		"--plugin=protoc-gen-go-lite="+plugin,
+		"--go-lite_out="+outDir,
+		"--go-lite_opt=features=size+marshal,paths=source_relative,registry=true",
+		protoPath,
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected registry feature validation failure")
+	}
+	if !strings.Contains(string(out), "registry=true requires size, marshal, and unmarshal features") {
+		t.Fatalf("unexpected error:\n%s", out)
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -61,6 +61,8 @@ type Config struct {
 	WellKnownTypes  bool
 	AllowEmpty      bool
 	BuildTag        string
+	// Registry generates init-time message constructor and option registration.
+	Registry bool
 }
 
 type CodegenMode string
@@ -106,6 +108,11 @@ func NewGenerator(plugin *protogen.Plugin, featureNames []string, cfg *Config) (
 	if err != nil {
 		return nil, err
 	}
+	if cfg != nil && cfg.Registry {
+		if err := validateRegistryFeatures(featureNames); err != nil {
+			return nil, err
+		}
+	}
 
 	local := make(map[protoreflect.FullName]bool)
 	for _, f := range plugin.Files {
@@ -148,6 +155,10 @@ func (gen *Generator) Generate() {
 
 		// Generate vtproto features
 		gen.generateFile(p, file)
+
+		if gen.cfg.Registry {
+			gen.generateRegistry(p, file)
+		}
 	}
 }
 

--- a/generator/registry.go
+++ b/generator/registry.go
@@ -1,0 +1,86 @@
+package generator
+
+import (
+	"cmp"
+	"errors"
+	"slices"
+	"strconv"
+
+	"github.com/aperturerobotics/protobuf-go-lite/compiler/protogen"
+)
+
+const registryPackage = protogen.GoImportPath("github.com/aperturerobotics/protobuf-go-lite/registry")
+
+func (gen *Generator) generateRegistry(p *GeneratedFile, file *protogen.File) {
+	var messages []*protogen.Message
+	var collect func([]*protogen.Message)
+	collect = func(msgs []*protogen.Message) {
+		for _, message := range msgs {
+			collect(message.Messages)
+			if message.Desc.IsMapEntry() {
+				continue
+			}
+			messages = append(messages, message)
+		}
+	}
+	collect(file.Messages)
+	if len(messages) == 0 {
+		return
+	}
+	slices.SortFunc(messages, func(a, b *protogen.Message) int {
+		return cmp.Compare(a.Desc.FullName(), b.Desc.FullName())
+	})
+
+	registryIdent := p.QualifiedGoIdent(registryPackage.Ident("Register"))
+	entryIdent := p.QualifiedGoIdent(registryPackage.Ident("Entry"))
+	optionIdent := p.QualifiedGoIdent(registryPackage.Ident("Option"))
+	messageIdent := p.QualifiedGoIdent(protogen.ProtobufGoLitePackage.Ident("Message"))
+
+	p.P("func init() {")
+	for _, message := range messages {
+		fullName := string(message.Desc.FullName())
+		typeURL := "type.googleapis.com/" + fullName
+		opts := collectMessageOptions(file, message)
+
+		p.P(registryIdent, "(", entryIdent, "{")
+		p.P("FullName: ", strconv.Quote(fullName), ",")
+		p.P("TypeURL: ", strconv.Quote(typeURL), ",")
+		p.P("New: func() ", messageIdent, " {")
+		p.P("return new(", message.GoIdent.GoName, ")")
+		p.P("},")
+		if len(opts) > 0 {
+			p.P("Options: []", optionIdent, "{")
+			for _, opt := range opts {
+				p.P("{")
+				p.P("Name: ", strconv.Quote(opt.Name), ",")
+				p.P("Values: []string{")
+				for _, v := range opt.Values {
+					p.P(strconv.Quote(v), ",")
+				}
+				p.P("},")
+				p.P("},")
+			}
+			p.P("},")
+		}
+		p.P("})")
+	}
+	p.P("}")
+	p.P()
+}
+
+func validateRegistryFeatures(featureNames []string) error {
+	all := slices.Contains(featureNames, "all")
+	for _, required := range []string{"size", "marshal", "unmarshal"} {
+		if all {
+			if _, ok := defaultFeatures[required]; ok {
+				continue
+			}
+		} else if slices.Contains(featureNames, required) {
+			continue
+		}
+		return errRegistryFeatures
+	}
+	return nil
+}
+
+var errRegistryFeatures = errors.New("registry=true requires size, marshal, and unmarshal features")

--- a/generator/registry_api_test.go
+++ b/generator/registry_api_test.go
@@ -1,0 +1,34 @@
+package generator_test
+
+import (
+	"testing"
+
+	"github.com/aperturerobotics/protobuf-go-lite/compiler/protogen"
+	_ "github.com/aperturerobotics/protobuf-go-lite/features/marshal"
+	_ "github.com/aperturerobotics/protobuf-go-lite/features/size"
+	_ "github.com/aperturerobotics/protobuf-go-lite/features/unmarshal"
+	"github.com/aperturerobotics/protobuf-go-lite/generator"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+func TestNewGeneratorValidatesRegistryFeatures(t *testing.T) {
+	plugin, err := (protogen.Options{}).New(&pluginpb.CodeGeneratorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, features := range [][]string{
+		{"size", "marshal"},
+		{"size", "unmarshal"},
+		{"marshal", "unmarshal"},
+	} {
+		_, err := generator.NewGenerator(plugin, features, &generator.Config{Registry: true})
+		if err == nil {
+			t.Fatalf("NewGenerator(%q) accepted registry without all message features", features)
+		}
+	}
+
+	if _, err := generator.NewGenerator(plugin, []string{"size", "marshal", "unmarshal"}, &generator.Config{Registry: true}); err != nil {
+		t.Fatalf("NewGenerator rejected complete registry features: %v", err)
+	}
+}

--- a/generator/registry_options.go
+++ b/generator/registry_options.go
@@ -1,0 +1,145 @@
+package generator
+
+import (
+	"encoding/base64"
+	"slices"
+	"strconv"
+
+	"github.com/aperturerobotics/protobuf-go-lite/compiler/protogen"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+type flatOption struct {
+	Name   string
+	Values []string
+}
+
+func collectMessageOptions(file *protogen.File, message *protogen.Message) []flatOption {
+	dp := descriptorProtoForMessage(file, message)
+	if dp == nil {
+		return nil
+	}
+	opts := dp.GetOptions()
+	if opts == nil {
+		return nil
+	}
+
+	var order []string
+	byName := make(map[string][]string)
+	opts.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if !fd.IsExtension() {
+			return true
+		}
+		flattenOptionValue(string(fd.FullName()), fd, v, &order, byName)
+		return true
+	})
+
+	slices.Sort(order)
+	out := make([]flatOption, 0, len(order))
+	for _, name := range order {
+		out = append(out, flatOption{Name: name, Values: byName[name]})
+	}
+	return out
+}
+
+func descriptorProtoForMessage(file *protogen.File, message *protogen.Message) *descriptorpb.DescriptorProto {
+	path := messageDescriptorPath(message.Desc)
+	list := file.Proto.GetMessageType()
+	var cur *descriptorpb.DescriptorProto
+	for i, idx := range path {
+		if idx < 0 || idx >= len(list) {
+			return nil
+		}
+		cur = list[idx]
+		if i == len(path)-1 {
+			return cur
+		}
+		list = cur.GetNestedType()
+	}
+	return nil
+}
+
+func messageDescriptorPath(md protoreflect.MessageDescriptor) []int {
+	var path []int
+	for {
+		path = append(path, md.Index())
+		parent, ok := md.Parent().(protoreflect.MessageDescriptor)
+		if !ok {
+			break
+		}
+		md = parent
+	}
+	slices.Reverse(path)
+	return path
+}
+
+func flattenOptionValue(prefix string, fd protoreflect.FieldDescriptor, v protoreflect.Value, order *[]string, byName map[string][]string) {
+	if fd.IsList() {
+		list := v.List()
+		for i := 0; i < list.Len(); i++ {
+			flattenOptionSingular(prefix, fd, list.Get(i), order, byName)
+		}
+		return
+	}
+	if fd.IsMap() {
+		mapv := v.Map()
+		mapv.Range(func(k protoreflect.MapKey, mv protoreflect.Value) bool {
+			keyName := prefix + "." + k.String()
+			flattenOptionSingular(keyName, fd.MapValue(), mv, order, byName)
+			return true
+		})
+		return
+	}
+	flattenOptionSingular(prefix, fd, v, order, byName)
+}
+
+func flattenOptionSingular(prefix string, fd protoreflect.FieldDescriptor, v protoreflect.Value, order *[]string, byName map[string][]string) {
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		msg := v.Message()
+		msg.Range(func(fd2 protoreflect.FieldDescriptor, v2 protoreflect.Value) bool {
+			flattenOptionValue(prefix+"."+string(fd2.Name()), fd2, v2, order, byName)
+			return true
+		})
+	default:
+		appendFlatOption(prefix, scalarOptionString(fd, v), order, byName)
+	}
+}
+
+func appendFlatOption(name, value string, order *[]string, byName map[string][]string) {
+	if _, ok := byName[name]; !ok {
+		*order = append(*order, name)
+	}
+	byName[name] = append(byName[name], value)
+}
+
+func scalarOptionString(fd protoreflect.FieldDescriptor, v protoreflect.Value) string {
+	switch fd.Kind() {
+	case protoreflect.BoolKind:
+		return strconv.FormatBool(v.Bool())
+	case protoreflect.EnumKind:
+		if ev := fd.Enum().Values().ByNumber(v.Enum()); ev != nil {
+			return string(ev.Name())
+		}
+		return strconv.FormatInt(int64(v.Enum()), 10)
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return strconv.FormatInt(v.Int(), 10)
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return strconv.FormatInt(v.Int(), 10)
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return strconv.FormatUint(v.Uint(), 10)
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return strconv.FormatUint(v.Uint(), 10)
+	case protoreflect.FloatKind:
+		return strconv.FormatFloat(v.Float(), 'g', -1, 32)
+	case protoreflect.DoubleKind:
+		return strconv.FormatFloat(v.Float(), 'g', -1, 64)
+	case protoreflect.StringKind:
+		return v.String()
+	case protoreflect.BytesKind:
+		return base64.StdEncoding.EncodeToString(v.Bytes())
+	default:
+		return v.String()
+	}
+}

--- a/generator/registry_test.go
+++ b/generator/registry_test.go
@@ -1,0 +1,16 @@
+package generator
+
+import "testing"
+
+func TestValidateRegistryFeaturesAllRequiresRegisteredFeatures(t *testing.T) {
+	features := defaultFeatures
+	defaultFeatures = map[string]Feature{
+		"marshal": nil,
+		"size":    nil,
+	}
+	t.Cleanup(func() { defaultFeatures = features })
+
+	if err := validateRegistryFeatures([]string{"all"}); err == nil {
+		t.Fatal("registry accepted all without a registered unmarshal feature")
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,204 @@
+// Package registry indexes generated protobuf-go-lite message constructors and
+// their statically generated custom options.
+package registry
+
+import (
+	"cmp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	protobuf_go_lite "github.com/aperturerobotics/protobuf-go-lite"
+	anypb_resolver "github.com/aperturerobotics/protobuf-go-lite/types/known/anypb/resolver"
+)
+
+// ErrNotFound is returned when a message type is not registered.
+var ErrNotFound = anypb_resolver.ErrNotFound
+
+// Option contains the flattened values of one custom message option.
+type Option struct {
+	// Name is the fully qualified option name followed by its message field path.
+	Name string
+	// Values contains repeated values in declaration order.
+	Values []string
+}
+
+// Entry describes one generated protobuf message type.
+type Entry struct {
+	// FullName is the fully qualified protobuf message name.
+	FullName string
+	// TypeURL is the canonical google.protobuf.Any type URL.
+	TypeURL string
+	// New constructs an empty message.
+	New func() protobuf_go_lite.Message
+	// Options contains the message's flattened custom options.
+	Options []Option
+}
+
+// Option returns the first value registered under name.
+func (e Entry) Option(name string) (string, bool) {
+	for _, opt := range e.Options {
+		if opt.Name == name && len(opt.Values) != 0 {
+			return opt.Values[0], true
+		}
+	}
+	return "", false
+}
+
+// Registry indexes message constructors by full name and type URL.
+type Registry struct {
+	mu      sync.RWMutex
+	byName  map[string]Entry
+	byURL   map[string]Entry
+	entries []Entry
+}
+
+var _ anypb_resolver.AnyTypeResolver = (*Registry)(nil)
+
+// NewRegistry constructs an empty message registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		byName: make(map[string]Entry),
+		byURL:  make(map[string]Entry),
+	}
+}
+
+// Register adds e to the registry. It copies the option metadata and panics if
+// FullName is empty, New is nil, or FullName is already registered.
+func (r *Registry) Register(e Entry) {
+	if e.FullName == "" {
+		panic("registry: Entry.FullName is required")
+	}
+	if e.New == nil {
+		panic("registry: Entry.New is required")
+	}
+	if e.TypeURL == "" {
+		e.TypeURL = "type.googleapis.com/" + e.FullName
+	}
+
+	e = copyEntry(e)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.byName[e.FullName]; ok {
+		panic("registry: duplicate registration for " + strconv.Quote(e.FullName))
+	}
+	r.byName[e.FullName] = e
+	r.byURL[e.TypeURL] = e
+	r.byURL[e.FullName] = e
+	r.entries = append(r.entries, e)
+	slices.SortFunc(r.entries, func(a, b Entry) int {
+		return cmp.Compare(a.FullName, b.FullName)
+	})
+}
+
+// All returns a full-name-sorted snapshot of the registered entries.
+func (r *Registry) All() []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Entry, len(r.entries))
+	for i, e := range r.entries {
+		out[i] = copyEntry(e)
+	}
+	return out
+}
+
+// Range calls fn for each entry in full-name order until fn returns false.
+// The callback runs without holding the registry lock.
+func (r *Registry) Range(fn func(Entry) bool) {
+	for _, e := range r.All() {
+		if !fn(e) {
+			return
+		}
+	}
+}
+
+// NewByName constructs the message registered under its full protobuf name.
+func (r *Registry) NewByName(name string) (protobuf_go_lite.Message, bool) {
+	r.mu.RLock()
+	e, ok := r.byName[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return e.New(), true
+}
+
+// NewByTypeURL constructs the message named by url.
+func (r *Registry) NewByTypeURL(url string) (protobuf_go_lite.Message, bool) {
+	r.mu.RLock()
+	e, ok := r.lookupByTypeURLLocked(url)
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return e.New(), true
+}
+
+// FindMessageByURL returns the constructor named by url.
+func (r *Registry) FindMessageByURL(url string) (func() protobuf_go_lite.Message, error) {
+	r.mu.RLock()
+	e, ok := r.lookupByTypeURLLocked(url)
+	r.mu.RUnlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	newFn := e.New
+	return newFn, nil
+}
+
+func (r *Registry) lookupByTypeURLLocked(url string) (Entry, bool) {
+	if e, ok := r.byURL[url]; ok {
+		return e, true
+	}
+	name := url
+	if i := strings.LastIndex(url, "/"); i >= 0 {
+		name = url[i+1:]
+	}
+	e, ok := r.byName[name]
+	return e, ok
+}
+
+func copyEntry(e Entry) Entry {
+	out := Entry{
+		FullName: e.FullName,
+		TypeURL:  e.TypeURL,
+		New:      e.New,
+	}
+	if len(e.Options) > 0 {
+		out.Options = make([]Option, len(e.Options))
+		for i, opt := range e.Options {
+			out.Options[i] = Option{
+				Name:   opt.Name,
+				Values: slices.Clone(opt.Values),
+			}
+		}
+	}
+	return out
+}
+
+var defaultRegistry = NewRegistry()
+
+// Register adds e to the default registry.
+func Register(e Entry) { defaultRegistry.Register(e) }
+
+// All returns a snapshot of the default registry.
+func All() []Entry { return defaultRegistry.All() }
+
+// Range calls fn for each entry in the default registry.
+func Range(fn func(Entry) bool) { defaultRegistry.Range(fn) }
+
+// NewByName constructs a message from the default registry by full name.
+func NewByName(name string) (protobuf_go_lite.Message, bool) {
+	return defaultRegistry.NewByName(name)
+}
+
+// NewByTypeURL constructs a message from the default registry by type URL.
+func NewByTypeURL(url string) (protobuf_go_lite.Message, bool) {
+	return defaultRegistry.NewByTypeURL(url)
+}
+
+// Default returns the registry populated by generated init functions.
+func Default() *Registry { return defaultRegistry }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,150 @@
+package registry
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	protobuf_go_lite "github.com/aperturerobotics/protobuf-go-lite"
+	"github.com/aperturerobotics/protobuf-go-lite/types/known/anypb"
+)
+
+type stubMsg struct{}
+
+func (m *stubMsg) Reset()      {}
+func (m *stubMsg) SizeVT() int { return 0 }
+func (m *stubMsg) MarshalVT() ([]byte, error) {
+	return nil, nil
+}
+func (m *stubMsg) MarshalToSizedBufferVT([]byte) (int, error) { return 0, nil }
+func (m *stubMsg) UnmarshalVT([]byte) error                   { return nil }
+
+func TestRegistryRegisterAndLookup(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Entry{
+		FullName: "demo.ClickEvents",
+		New:      func() protobuf_go_lite.Message { return &stubMsg{} },
+		Options: []Option{
+			{Name: "annotations.msg_opts.tenant", Values: []string{"BLINKIT"}},
+			{Name: "annotations.msg_opts.table", Values: []string{"click_events"}},
+			{Name: "annotations.msg_opts.tenants", Values: []string{"BLINKIT", "ZOMATO"}},
+			{Name: "annotations.msg_opts.empty"},
+		},
+	})
+
+	msg, ok := r.NewByName("demo.ClickEvents")
+	if !ok || msg == nil {
+		t.Fatal("NewByName failed")
+	}
+	msg, ok = r.NewByTypeURL("type.googleapis.com/demo.ClickEvents")
+	if !ok || msg == nil {
+		t.Fatal("NewByTypeURL failed")
+	}
+	msg, ok = r.NewByTypeURL("demo.ClickEvents")
+	if !ok || msg == nil {
+		t.Fatal("NewByTypeURL by name failed")
+	}
+
+	entries := r.All()
+	if len(entries) != 1 {
+		t.Fatalf("All len=%d", len(entries))
+	}
+	tenant, ok := entries[0].Option("annotations.msg_opts.tenant")
+	if !ok || tenant != "BLINKIT" {
+		t.Fatalf("tenant=%q ok=%v", tenant, ok)
+	}
+	if _, ok := entries[0].Option("missing"); ok {
+		t.Fatal("missing option should be absent")
+	}
+	if _, ok := entries[0].Option("annotations.msg_opts.empty"); ok {
+		t.Fatal("option without values should be absent")
+	}
+
+	var saw string
+	r.Range(func(e Entry) bool {
+		saw = e.FullName
+		return true
+	})
+	if saw != "demo.ClickEvents" {
+		t.Fatalf("Range saw %q", saw)
+	}
+
+	fn, err := r.FindMessageByURL("type.googleapis.com/demo.ClickEvents")
+	if err != nil || fn == nil || fn() == nil {
+		t.Fatalf("FindMessageByURL err=%v", err)
+	}
+	_, err = r.FindMessageByURL("type.googleapis.com/demo.Missing")
+	if err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	_, err = anypb.UnmarshalNew(
+		&anypb.Any{TypeUrl: "type.googleapis.com/demo.Missing"},
+		"",
+		r,
+	)
+	if !errors.Is(err, anypb.ErrNotFound) {
+		t.Fatalf("UnmarshalNew error = %v, want anypb.ErrNotFound", err)
+	}
+}
+
+func TestRegistryDuplicatePanics(t *testing.T) {
+	r := NewRegistry()
+	e := Entry{
+		FullName: "demo.Dup",
+		New:      func() protobuf_go_lite.Message { return &stubMsg{} },
+	}
+	r.Register(e)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	r.Register(e)
+}
+
+func TestRegistryConcurrentReads(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Entry{
+		FullName: "demo.A",
+		New:      func() protobuf_go_lite.Message { return &stubMsg{} },
+	})
+	r.Register(Entry{
+		FullName: "demo.B",
+		New:      func() protobuf_go_lite.Message { return &stubMsg{} },
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = r.All()
+				r.Range(func(Entry) bool { return true })
+				_, _ = r.NewByName("demo.A")
+				_, _ = r.NewByTypeURL("type.googleapis.com/demo.B")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRegistryAllSortedAndCopied(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Entry{FullName: "demo.B", New: func() protobuf_go_lite.Message { return &stubMsg{} }})
+	r.Register(Entry{
+		FullName: "demo.A",
+		New:      func() protobuf_go_lite.Message { return &stubMsg{} },
+		Options:  []Option{{Name: "k", Values: []string{"v"}}},
+	})
+	all := r.All()
+	if all[0].FullName != "demo.A" || all[1].FullName != "demo.B" {
+		t.Fatalf("unsorted: %#v", all)
+	}
+	all[0].Options[0].Values[0] = "mutated"
+	all2 := r.All()
+	if all2[0].Options[0].Values[0] != "v" {
+		t.Fatal("All should return copied metadata")
+	}
+}

--- a/types/known/anypb/any.go
+++ b/types/known/anypb/any.go
@@ -21,7 +21,7 @@ import (
 type MessageTypeResolver = anypb_resolver.AnyTypeResolver
 
 // ErrNotFound is returned if the message type was not found.
-var ErrNotFound = errors.New("message type not found in Any")
+var ErrNotFound = anypb_resolver.ErrNotFound
 
 // New marshals src into a new Any instance.
 func New(src protobuf_go_lite.Message, typeURL string) (*Any, error) {

--- a/types/known/anypb/resolver/resolver.go
+++ b/types/known/anypb/resolver/resolver.go
@@ -9,6 +9,9 @@ import (
 // ErrNoAnyTypeResolver is returned if no resolver was provided for the Any type.
 var ErrNoAnyTypeResolver = errors.New("no resolver provided for the Any type")
 
+// ErrNotFound is returned if the message type was not found.
+var ErrNotFound = errors.New("message type not found in Any")
+
 // AnyTypeResolver is an interface for looking up messages.
 //
 // A compliant implementation must deterministically return the same type


### PR DESCRIPTION
Closes #45

## Summary

- Adds opt-in `registry=true` flag to `protoc-gen-go-lite` (disabled by default)
- Emits `init()` registrations into a new `registry` package: `FullName`, `TypeURL`, `New()`, and flattened custom `MessageOptions` extensions
- Runtime API: `registry.NewByName`, `NewByTypeURL`, `Range`, `Entry.Option(name)`
- Validates that `registry=true` requires `size`, `marshal`, and `unmarshal` features

## Motivation

Consumers routing JSON→protobuf by custom proto options (e.g. `tenant` + `table` on `msg_opts`) currently need a separate codegen step against the std protobuf registry. This bakes option metadata into generated lite code at compile time so a single lite client can resolve message types at runtime.

## Example

```bash
protoc --go-lite_opt=features=all,registry=true ...
```

Generated tail of `.pb.go`:

```go
func init() {
    registry.Register(registry.Entry{
        FullName: "demo.ClickEvents",
        TypeURL:  "type.googleapis.com/demo.ClickEvents",
        New: func() protobuf_go_lite.Message { return new(ClickEvents) },
        Options: []registry.Option{
            {Name: "annotations.msg_opts.tenant", Values: []string{"BLINKIT"}},
            {Name: "annotations.msg_opts.table", Values: []string{"click_events"}},
        },
    })
}
```

## Test plan

- [x] `go test ./...`
- [x] `TestRegistryOptInGeneratesInitAndOptions` — codegen + runtime lookup by flattened options
- [x] `TestRegistryDisabledByDefault` — no registry emission without flag
- [x] `TestRegistryRequiresFeatures` — rejects `registry=true` without wire codecs


Made with [Cursor](https://cursor.com)