### PR TITLE
fix(json): emit RFC 8259 string escapes

### DIFF
--- a/json/marshal_test.go
+++ b/json/marshal_test.go
@@ -5,6 +5,7 @@ package json
 
 import (
 	"bytes"
+	stdjson "encoding/json"
 	"math"
 	"testing"
 	"time"
@@ -207,6 +208,37 @@ func TestMarshalSlice(t *testing.T) {
 
 	if string(result) != expected {
 		t.Errorf("MarshalSlice result does not match expected.\nGot:      %s\nExpected: %s", string(result), expected)
+	}
+}
+
+type stringMarshaler struct {
+	value string
+}
+
+func (m *stringMarshaler) MarshalProtoJSON(s *MarshalState) {
+	s.WriteObjectStart()
+	s.WriteObjectField("value")
+	s.WriteString(m.value)
+	s.WriteObjectEnd()
+}
+
+func TestMarshalStringUsesJSONEscapes(t *testing.T) {
+	want := "\a\v\x1b\"\\\u2028\u2029"
+	encoded, err := Marshal(DefaultMarshalerConfig, &stringMarshaler{value: want})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stdjson.Valid(encoded) {
+		t.Fatalf("Marshal emitted invalid JSON: %q", encoded)
+	}
+	var decoded struct {
+		Value string `json:"value"`
+	}
+	if err := stdjson.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Value != want {
+		t.Fatalf("decoded string = %q, want %q", decoded.Value, want)
 	}
 }
 

--- a/json/stream.go
+++ b/json/stream.go
@@ -3,7 +3,41 @@ package json
 import (
 	"io"
 	"strconv"
+	"unicode/utf8"
 )
+
+const jsonHex = "0123456789abcdef"
+
+func appendJSONString(dst []byte, str string) []byte {
+	dst = append(dst, '"')
+	for len(str) != 0 {
+		r, size := utf8.DecodeRuneInString(str)
+		str = str[size:]
+		switch r {
+		case '"', '\\':
+			dst = append(dst, '\\', byte(r))
+		case '\b':
+			dst = append(dst, '\\', 'b')
+		case '\f':
+			dst = append(dst, '\\', 'f')
+		case '\n':
+			dst = append(dst, '\\', 'n')
+		case '\r':
+			dst = append(dst, '\\', 'r')
+		case '\t':
+			dst = append(dst, '\\', 't')
+		case '\u2028', '\u2029':
+			dst = append(dst, '\\', 'u', '2', '0', '2', jsonHex[r&0xf])
+		default:
+			if r < ' ' {
+				dst = append(dst, '\\', 'u', '0', '0', jsonHex[r>>4], jsonHex[r&0xf])
+			} else {
+				dst = utf8.AppendRune(dst, r)
+			}
+		}
+	}
+	return append(dst, '"')
+}
 
 // JsonStream is an outgoing stream of json.
 type JsonStream struct {
@@ -32,7 +66,8 @@ func (s *JsonStream) Write(p []byte) (n int, err error) {
 // WriteString writes a quoted string into the stream.
 func (s *JsonStream) WriteString(str string) {
 	if s.err == nil {
-		_, s.err = io.WriteString(s.wr, strconv.Quote(str))
+		encoded := appendJSONString(make([]byte, 0, len(str)+2), str)
+		_, s.err = s.wr.Write(encoded)
 	}
 }
 


### PR DESCRIPTION
Encode protobuf string fields with the package JSON stream instead of Go string quoting. This keeps the runtime reflect-free while preventing Go-only escapes such as `\\x1b`, `\\a`, and `\\v` from entering protobuf JSON output. The regression covers controls, quotes, backslashes, and Unicode separators and verifies standards-compliant round-trip decoding.